### PR TITLE
The @alanz repo fails to clone, use digital-assets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "ghcide"]
 	path = ghcide
-	# url = https://github.com/digital-asset/ghcide.git
-	url = https://github.com/alanz/ghcide.git
+	url = https://github.com/digital-asset/ghcide.git


### PR DESCRIPTION
N.B. The below git error when doing a submodule init or recursive clone
with the alanz repo as the submodule.

Admittedly this is quite likely the wrong fix and instead whatever is going on cloning alanz/ghcide should be fixed instead.

```
error: Server does not allow request for unadvertised object 956e11dff8059b1b78ea487db7d6dcb3430ad6c4
Fetched in submodule path 'ghcide', but it did not contain 956e11dff8059b1b78ea487db7d6dcb3430ad6c4. D
irect fetching of that commit failed.
```