### PR TITLE
The target is 'haskell-ide' not 'ide' - change it in hie.yaml.cbl

### DIFF
--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -9,7 +9,7 @@ cradle:
       component: "ide:test"
 
     - path: "./exe"
-      component: "ide:exe:ide"
+      component: "ide:exe:haskell-ide"
 
     - path: "./src"
       component: "lib:ide"


### PR DESCRIPTION
N.B. this might need a matching change to the stack hie.yml.