### PR TITLE
Brute-force copy of install.hs from hie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ hie.yaml
 cabal.project.local
 *~
 *.lock
+
+# shake build information
+_build/
+
+# stack 2.1 stack.yaml lock files
+stack*.yaml.lock
+shake.yaml.lock

--- a/install.hs
+++ b/install.hs
@@ -1,0 +1,21 @@
+#!/usr/bin/env stack
+{- stack
+  runghc
+  --stack-yaml=install/shake.yaml
+  --package hie-install
+-}
+{- cabal:
+build-depends:
+    base
+  , hie-install
+-}
+-- call as:
+-- * `cabal v2-run install.hs --project-file install/shake.project <target>`
+-- * `stack install.hs <target>`
+
+-- TODO: set `shake.project` in cabal-config above, when supported
+-- (see https://github.com/haskell/cabal/issues/6353)
+
+import HieInstall (defaultMain)
+
+main = defaultMain

--- a/install/Setup.hs
+++ b/install/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/install/cabal.project
+++ b/install/cabal.project
@@ -1,0 +1,2 @@
+packages:
+         ./

--- a/install/hie-install.cabal
+++ b/install/hie-install.cabal
@@ -1,0 +1,40 @@
+name:                hie-install
+version:             0.8.0.0
+synopsis:            Install the haskell-ide-engine
+license:             BSD3
+author:              Many, TBD when we release
+maintainer:          samuel.pilz@posteo.net
+copyright:           2019
+build-type:          Simple
+cabal-version:       >=2.0
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     HieInstall
+  other-modules:       BuildSystem
+                     , Stack
+                     , Version
+                     , Cabal
+                     , Print
+                     , Env
+                     , Help
+  build-depends:       base >= 4.9 && < 5
+                     , shake >= 0.16.4 && < 0.19
+                     , directory
+                     , filepath
+                     , extra
+                     , text
+  default-extensions: LambdaCase
+                    , TupleSections
+                    , RecordWildCards
+  default-language:    Haskell2010
+
+  if flag(run-from-stack)
+    cpp-options:       -DRUN_FROM_STACK
+  else
+    build-depends: cabal-install-parsers
+
+flag run-from-stack
+  description:         Inform the application that it is run from stack
+  default:             False
+  manual:              True

--- a/install/shake.project
+++ b/install/shake.project
@@ -1,0 +1,2 @@
+packages:
+         install/

--- a/install/shake.yaml
+++ b/install/shake.yaml
@@ -1,0 +1,11 @@
+# Used to provide a different environment for the shake build script
+resolver: lts-14.11 # GHC 8.6.5
+packages:
+- .
+
+nix:
+  packages: [ zlib ]
+
+flags:
+  hie-install:
+    run-from-stack: true

--- a/install/src/BuildSystem.hs
+++ b/install/src/BuildSystem.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+
+module BuildSystem where
+
+buildSystem :: String
+buildSystem =
+#if RUN_FROM_STACK
+  "stack"
+#else
+  "cabal"
+#endif
+
+isRunFromStack :: Bool
+isRunFromStack = buildSystem == "stack"
+
+isRunFromCabal :: Bool
+isRunFromCabal = buildSystem == "cabal"

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -36,7 +36,7 @@ execCabal :: CmdResult r => [String] -> Action r
 execCabal = command [] "cabal"
 
 execCabal_ :: [String] -> Action ()
-execCabal_ = command [] "cabal"
+execCabal_ = execCabal
 
 cabalBuildData :: Action ()
 cabalBuildData = do

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE CPP #-}
+
+module Cabal where
+
+import           Development.Shake
+import           Development.Shake.Command
+import           Development.Shake.FilePath
+import           Control.Monad
+import           Data.Maybe                               ( isNothing
+                                                          , isJust
+                                                          )
+import           Control.Monad.Extra                      ( whenMaybe )
+import           System.Directory                         ( findExecutable
+                                                          , copyFile
+                                                          )
+
+import           Version
+import           Print
+import           Env
+import           Data.Functor.Identity
+#if RUN_FROM_STACK
+import           Control.Exception                        ( throwIO )
+#else
+import           Cabal.Config
+#endif
+
+getInstallDir :: IO FilePath
+#if RUN_FROM_STACK
+-- we should never hit this codepath
+getInstallDir = throwIO $ userError "Stack and cabal should never be mixed"
+#else
+getInstallDir = runIdentity . cfgInstallDir <$> readConfig
+#endif
+
+execCabal :: CmdResult r => [String] -> Action r
+execCabal = command [] "cabal"
+
+execCabal_ :: [String] -> Action ()
+execCabal_ = command [] "cabal"
+
+cabalBuildData :: Action ()
+cabalBuildData = do
+  execCabal_ ["v2-build", "hoogle"]
+  execCabal_ ["v2-exec", "hoogle", "generate"]
+
+getGhcPathOfOrThrowError :: VersionNumber -> Action GhcPath
+getGhcPathOfOrThrowError versionNumber =
+  getGhcPathOf versionNumber >>= \case
+    Nothing -> do
+      printInStars $ ghcVersionNotFoundFailMsg versionNumber
+      error (ghcVersionNotFoundFailMsg versionNumber)
+    Just p -> return p
+
+cabalInstallHie :: VersionNumber -> Action ()
+cabalInstallHie versionNumber = do
+  localBin <- liftIO $ getInstallDir
+  cabalVersion <- getCabalVersion
+  ghcPath <- getGhcPathOfOrThrowError versionNumber
+
+  let isCabal3 = checkVersion [3,0,0,0] cabalVersion
+      installDirOpt | isCabal3 = "--installdir"
+                    | otherwise = "--symlink-bindir"
+      installMethod | isWindowsSystem && isCabal3 = ["--install-method=copy"]
+                    | otherwise = []
+  execCabal_ $
+    [ "v2-install"
+    , "-w", ghcPath
+    , "--write-ghc-environment-files=never"
+    , installDirOpt, localBin
+    , "--max-backjumps=5000"
+    , "exe:haskell-ide"
+    , "--overwrite-policy=always"
+    ]
+    ++ installMethod
+
+  let minorVerExe = "haskell-ide-" ++ versionNumber <.> exe
+      majorVerExe = "haskell-ide-" ++ dropExtension versionNumber <.> exe
+
+  liftIO $ do
+    copyFile (localBin </> "haskell-ide" <.> exe) (localBin </> minorVerExe)
+    copyFile (localBin </> "haskell-ide" <.> exe) (localBin </> majorVerExe)
+
+  printLine $   "Copied executables "
+             ++ ("haskell-ide-wrapper" <.> exe) ++ ", "
+             ++ ("haskell-ide" <.> exe) ++ ", "
+             ++ majorVerExe ++ " and "
+             ++ minorVerExe
+             ++ " to " ++ localBin
+
+checkCabal_ :: Action ()
+checkCabal_ = checkCabal >> return ()
+
+-- | check `cabal` has the required version
+checkCabal :: Action String
+checkCabal = do
+  cabalVersion <- getCabalVersion
+  unless (checkVersion requiredCabalVersion cabalVersion) $ do
+    printInStars $ cabalInstallIsOldFailMsg cabalVersion
+    error $ cabalInstallIsOldFailMsg cabalVersion
+  return cabalVersion
+
+getCabalVersion :: Action String
+getCabalVersion = trimmedStdout <$> execCabal ["--numeric-version"]
+
+-- | Error message when the `cabal` binary is an older version
+cabalInstallIsOldFailMsg :: String -> String
+cabalInstallIsOldFailMsg cabalVersion =
+  "The `cabal` executable found in $PATH is outdated.\n"
+    ++ "found version is `"
+    ++ cabalVersion
+    ++ "`.\n"
+    ++ "required version is `"
+    ++ versionToString requiredCabalVersion
+    ++ "`."
+
+
+requiredCabalVersion :: RequiredVersion
+requiredCabalVersion | isWindowsSystem = requiredCabalVersionForWindows
+                     | otherwise = [2, 4, 1, 0]
+
+requiredCabalVersionForWindows :: RequiredVersion
+requiredCabalVersionForWindows = [3, 0, 0, 0]

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -1,0 +1,116 @@
+module Env where
+
+import           Development.Shake
+import           Development.Shake.Command
+import           Control.Monad.IO.Class
+import           Control.Monad
+import           Development.Shake.FilePath
+import           System.Info                              ( os
+                                                          , arch
+                                                          )
+import           Data.Maybe                               ( isJust
+                                                          , isNothing
+                                                          , mapMaybe
+                                                          )
+import           System.Directory                         ( findExecutable
+                                                          , findExecutables
+                                                          , listDirectory
+                                                          )
+import           Data.Function                            ( (&)
+                                                          , on
+                                                          )
+import           Data.List                                ( sort
+                                                          , sortBy
+                                                          , isInfixOf
+                                                          , nubBy
+                                                          )
+import           Data.Ord                                 ( comparing )
+import           Control.Monad.Extra                      ( mapMaybeM )
+
+import qualified Data.Text                     as T
+
+import           Version
+import           Print
+
+
+type GhcPath = String
+
+existsExecutable :: MonadIO m => String -> m Bool
+existsExecutable executable = liftIO $ isJust <$> findExecutable executable
+
+
+-- | Check if the current system is windows
+isWindowsSystem :: Bool
+isWindowsSystem = os `elem` ["mingw32", "win32"]
+
+findInstalledGhcs :: IO [(VersionNumber, GhcPath)]
+findInstalledGhcs = do
+  hieVersions <- getHieVersions :: IO [VersionNumber]
+  knownGhcs <- mapMaybeM
+    (\version -> getGhcPathOf version >>= \case
+        Nothing -> return Nothing
+        Just p  -> return $ Just (version, p)
+    )
+    (reverse hieVersions)
+  -- filter out not supported ghc versions
+  availableGhcs <- filter ((`elem` hieVersions) . fst) <$> getGhcPaths
+  return
+    -- sort by version to make it coherent with getHieVersions
+    $ sortBy (comparing fst)
+    -- nub by version. knownGhcs takes precedence.
+    $ nubBy ((==) `on` fst)
+    -- filter out stack provided GHCs (assuming that stack programs path is the default one in linux)
+    $ filter (not . isInfixOf ".stack" . snd) (knownGhcs ++ availableGhcs)
+
+-- | Get the path to a GHC that has the version specified by `VersionNumber`
+-- If no such GHC can be found, Nothing is returned.
+-- First, it is checked whether there is a GHC with the name `ghc-$VersionNumber`.
+-- If this yields no result, it is checked, whether the numeric-version of the `ghc`
+-- command fits to the desired version.
+getGhcPathOf :: MonadIO m => VersionNumber -> m (Maybe GhcPath)
+getGhcPathOf ghcVersion =
+  liftIO $ findExecutable ("ghc-" ++ ghcVersion <.> exe) >>= \case
+    Nothing -> lookup ghcVersion <$> getGhcPaths
+    path -> return path
+
+-- | Get a list of GHCs that are available in $PATH
+getGhcPaths :: MonadIO m => m [(VersionNumber, GhcPath)]
+getGhcPaths = liftIO $ do
+  paths <- findExecutables "ghc"
+  forM paths $ \path -> do
+    Stdout version <- cmd path ["--numeric-version"]
+    return (trim version, path)
+
+-- | No suitable ghc version has been found. Show a message.
+ghcVersionNotFoundFailMsg :: VersionNumber -> String
+ghcVersionNotFoundFailMsg versionNumber =
+  "No GHC with version "
+    <> versionNumber
+    <> " has been found.\n"
+    <> "Either install a fitting GHC, use the stack targets or modify the PATH variable accordingly."
+
+
+-- | Defines all different hie versions that are buildable.
+--
+-- The current directory is scanned for `stack-*.yaml` files.
+getHieVersions :: MonadIO m => m [VersionNumber]
+getHieVersions = do
+  let stackYamlPrefix = T.pack "stack-"
+  let stackYamlSuffix = T.pack ".yaml"
+  files <- liftIO $ listDirectory "."
+  let hieVersions =
+        files
+          & map T.pack
+          & mapMaybe
+              (T.stripPrefix stackYamlPrefix >=> T.stripSuffix stackYamlSuffix)
+          & map T.unpack
+        -- the following line excludes `8.6.3`, `8.8.1` and `8.8.2` on windows systems
+          & filter (\p -> not (isWindowsSystem && p `elem` ["8.6.3", "8.8.1", "8.8.2"]))
+          & sort
+  return hieVersions
+
+
+-- | Most recent version of hie.
+-- Shown in the more concise help message.
+mostRecentHieVersion :: MonadIO m => m VersionNumber
+mostRecentHieVersion = last <$> getHieVersions

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -1,0 +1,124 @@
+-- |Module for Help messages and traget descriptions
+module Help where
+
+import           Development.Shake
+import           Data.List                                ( intersperse
+                                                          , intercalate
+                                                          )
+
+import           Env
+import           Print
+import           Version
+import           BuildSystem
+import           Cabal
+
+stackCommand :: TargetDescription -> String
+stackCommand target = "stack install.hs " ++ fst target
+
+cabalCommand :: TargetDescription -> String
+cabalCommand target = "cabal v2-run install.hs --project-file install/shake.project " ++ fst target
+
+buildCommand :: TargetDescription -> String
+buildCommand | isRunFromCabal = cabalCommand
+             | otherwise = stackCommand
+
+printUsage :: Action ()
+printUsage = do
+  printLine ""
+  printLine "Usage:"
+  printLineIndented (stackCommand templateTarget)
+  printLineIndented "or"
+  printLineIndented (cabalCommand templateTarget)
+
+-- | short help message is printed by default
+shortHelpMessage :: Action ()
+shortHelpMessage = do
+  hieVersions <- getHieVersions
+  printUsage
+  printLine ""
+  printLine "Targets:"
+  mapM_ (printLineIndented . showTarget (spaces hieVersions)) (targets hieVersions)
+  printLine ""
+ where
+  spaces hieVersions = space (targets hieVersions)
+  targets hieVersions =
+    [ ("help", "Show help message including all targets")
+    , emptyTarget
+    , buildTarget
+    , buildLatestTarget
+    , hieTarget $ last hieVersions
+    , buildDataTarget
+    , cabalGhcsTarget
+    ]
+
+-- | A record that specifies for each build system which versions of @haskell-ide@ can be built.
+data BuildableVersions = BuildableVersions
+  { stackVersions :: [VersionNumber]
+  , cabalVersions :: [VersionNumber]
+  }
+
+getDefaultBuildSystemVersions :: BuildableVersions -> [VersionNumber]
+getDefaultBuildSystemVersions BuildableVersions {..}
+  | isRunFromStack = stackVersions
+  | isRunFromCabal = cabalVersions
+  | otherwise      = error $ "unknown build system: " ++ buildSystem
+
+helpMessage :: BuildableVersions -> Action ()
+helpMessage versions@BuildableVersions {..} = do
+  printUsage
+  printLine ""
+  printLine "Targets:"
+  mapM_ (printLineIndented . showTarget spaces) targets
+  printLine ""
+ where
+  spaces = space targets
+  -- All targets the shake file supports
+  targets :: [(String, String)]
+  targets = intercalate
+    [emptyTarget]
+    [ generalTargets
+    , defaultTargets
+    , if isRunFromCabal then [cabalGhcsTarget] else []
+    , [macosIcuTarget]
+    ]
+
+  -- All targets with their respective help message.
+  generalTargets = [helpTarget]
+
+  defaultTargets = [buildTarget, buildLatestTarget, buildDataTarget]
+    ++ map hieTarget (getDefaultBuildSystemVersions versions)
+
+-- | Empty target. Purpose is to introduce a newline between the targets
+emptyTarget :: (String, String)
+emptyTarget = ("", "")
+
+templateTarget :: (String, String)
+templateTarget = ("<target>", "")
+
+hieTarget :: String -> TargetDescription
+hieTarget version =
+  ("haskell-ide-" ++ version, "Builds haskell-ide for GHC version " ++ version)
+
+buildTarget :: TargetDescription
+buildTarget = ("haskell-ide", "Build haskell-ide with the latest available GHC and the data files")
+
+buildLatestTarget :: TargetDescription
+buildLatestTarget = ("latest", "Build haskell-ide with the latest available GHC")
+
+buildDataTarget :: TargetDescription
+buildDataTarget =
+  ("data", "Get the required data-files for `haskell-ide` (Hoogle DB)")
+
+-- special targets
+
+macosIcuTarget :: TargetDescription
+macosIcuTarget = ("icu-macos-fix", "Fixes icu related problems in MacOS")
+
+helpTarget :: TargetDescription
+helpTarget = ("help", "Show help message including all targets")
+
+cabalGhcsTarget :: TargetDescription
+cabalGhcsTarget =
+  ( "ghcs"
+  , "Show all GHC versions that can be installed via `cabal-build`."
+  )

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -78,7 +78,7 @@ helpMessage versions@BuildableVersions {..} = do
     [emptyTarget]
     [ generalTargets
     , defaultTargets
-    , if isRunFromCabal then [cabalGhcsTarget] else []
+    , if isRunFromCabal then [cabalGhcsTarget] else [stackDevTarget]
     , [macosIcuTarget]
     ]
 
@@ -97,13 +97,13 @@ templateTarget = ("<target>", "")
 
 hieTarget :: String -> TargetDescription
 hieTarget version =
-  ("haskell-ide-" ++ version, "Builds haskell-ide for GHC version " ++ version)
+  ("haskell-ide-" ++ version, "Install haskell-ide for GHC version " ++ version)
 
 buildTarget :: TargetDescription
-buildTarget = ("haskell-ide", "Build haskell-ide with the latest available GHC and the data files")
+buildTarget = ("haskell-ide", "Install haskell-ide with the latest available GHC and the data files")
 
 buildLatestTarget :: TargetDescription
-buildLatestTarget = ("latest", "Build haskell-ide with the latest available GHC")
+buildLatestTarget = ("latest", "Install haskell-ide with the latest available GHC")
 
 buildDataTarget :: TargetDescription
 buildDataTarget =
@@ -122,3 +122,6 @@ cabalGhcsTarget =
   ( "ghcs"
   , "Show all GHC versions that can be installed via `cabal-build`."
   )
+
+stackDevTarget :: TargetDescription
+stackDevTarget = ("dev", "Install haskell-ide with the default stack.yaml")

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -79,14 +79,18 @@ defaultMain = do
         need ["submodules"]
         need ["check"]
         if isRunFromStack then do
-          stackBuildHie version
-          stackInstallHie version
+          stackInstallHieWithErrMsg (Just version)
         else
           cabalInstallHie version
       )
 
     phony "latest" (need ["haskell-ide-" ++ latestVersion])
     phony "haskell-ide"  (need ["data", "latest"])
+
+    -- stack specific targets
+    when isRunFromStack $ do
+
+      phony "dev" $ stackInstallHieWithErrMsg Nothing
 
     -- cabal specific targets
     when isRunFromCabal $ do

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -1,0 +1,124 @@
+module HieInstall where
+
+import           Development.Shake
+import           Development.Shake.Command
+import           Development.Shake.FilePath
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.Extra                      ( unlessM
+                                                          , mapMaybeM
+                                                          )
+import           Data.Maybe                               ( isJust )
+import           System.Directory                         ( listDirectory )
+import           System.Environment                       ( unsetEnv )
+import           System.Info                              ( os
+                                                          , arch
+                                                          )
+
+import           Data.Maybe                               ( isNothing
+                                                          , mapMaybe
+                                                          )
+import           Data.List                                ( dropWhileEnd
+                                                          , intersperse
+                                                          , intercalate
+                                                          , sort
+                                                          , sortOn
+                                                          )
+import qualified Data.Text                     as T
+import           Data.Char                                ( isSpace )
+import           Data.Version                             ( parseVersion
+                                                          , makeVersion
+                                                          , showVersion
+                                                          )
+import           Data.Function                            ( (&) )
+import           Text.ParserCombinators.ReadP             ( readP_to_S )
+
+import           BuildSystem
+import           Stack
+import           Cabal
+import           Version
+import           Print
+import           Env
+import           Help
+
+defaultMain :: IO ()
+defaultMain = do
+  -- unset GHC_PACKAGE_PATH for cabal
+  unsetEnv "GHC_PACKAGE_PATH"
+
+  -- used for cabal-based targets
+  ghcPaths <- findInstalledGhcs
+  let cabalVersions = map fst ghcPaths
+
+  -- used for stack-based targets
+  stackVersions <- getHieVersions
+
+  let versions = if isRunFromStack then stackVersions else cabalVersions
+
+  let toolsVersions = BuildableVersions stackVersions cabalVersions
+
+  let latestVersion = last versions
+
+  shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+    want ["short-help"]
+    -- general purpose targets
+    phony "submodules"  updateSubmodules
+    phony "short-help"  shortHelpMessage
+    phony "help"        (helpMessage toolsVersions)
+
+    phony "check" (if isRunFromStack then checkStack else checkCabal_)
+
+    phony "data" $ do
+      need ["submodules"]
+      need ["check"]
+      if isRunFromStack then stackBuildData else cabalBuildData
+
+    forM_
+      versions
+      (\version -> phony ("haskell-ide-" ++ version) $ do
+        need ["submodules"]
+        need ["check"]
+        if isRunFromStack then do
+          stackBuildHie version
+          stackInstallHie version
+        else
+          cabalInstallHie version
+      )
+
+    phony "latest" (need ["haskell-ide-" ++ latestVersion])
+    phony "haskell-ide"  (need ["data", "latest"])
+
+    -- cabal specific targets
+    when isRunFromCabal $ do
+
+      phony "ghcs" $ do
+        let
+          msg =
+            "Found the following GHC paths: \n"
+              ++ unlines
+                  (map (\(version, path) -> "ghc-" ++ version ++ ": " ++ path)
+                        ghcPaths
+                  )
+        printInStars msg
+
+    -- macos specific targets
+    phony "icu-macos-fix"
+          (need ["icu-macos-fix-install"] >> need ["icu-macos-fix-build"])
+    phony "icu-macos-fix-install" (command_ [] "brew" ["install", "icu4c"])
+    phony "icu-macos-fix-build" $ mapM_ buildIcuMacosFix versions
+
+
+buildIcuMacosFix :: VersionNumber -> Action ()
+buildIcuMacosFix version = execStackWithGhc_
+  version
+  [ "build"
+  , "text-icu"
+  , "--extra-lib-dirs=/usr/local/opt/icu4c/lib"
+  , "--extra-include-dirs=/usr/local/opt/icu4c/include"
+  ]
+
+-- | update the submodules that the project is in the state as required by the `stack.yaml` files
+updateSubmodules :: Action ()
+updateSubmodules = do
+  command_ [] "git" ["submodule", "sync"]
+  command_ [] "git" ["submodule", "update", "--init"]

--- a/install/src/Print.hs
+++ b/install/src/Print.hs
@@ -1,0 +1,47 @@
+module Print where
+
+import           Development.Shake
+import           Development.Shake.Command
+import           Control.Monad.IO.Class
+import           Data.List                                ( dropWhileEnd
+                                                          , dropWhile
+                                                          )
+import           Data.Char                                ( isSpace )
+
+-- | lift putStrLn to MonadIO
+printLine :: MonadIO m => String -> m ()
+printLine = liftIO . putStrLn
+
+-- | print a line prepended with 4 spaces
+printLineIndented :: MonadIO m => String -> m ()
+printLineIndented = printLine . ("    " ++)
+
+embedInStars :: String -> String
+embedInStars str =
+  let starsLine = "\n" <> replicate 80 '*' <> "\n"
+  in  starsLine <> str <> starsLine
+
+printInStars :: MonadIO m => String -> m ()
+printInStars = liftIO . putStrLn . embedInStars
+
+
+-- | Trim whitespace of both ends of a string
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+
+-- | Trim the whitespace of the stdout of a command
+trimmedStdout :: Stdout String -> String
+trimmedStdout (Stdout s) = trim s
+
+type TargetDescription = (String, String)
+
+-- | Number of spaces the target name including whitespace should have.
+-- At least twenty, maybe more if target names are long. At most the length of the longest target plus five.
+space :: [TargetDescription] -> Int
+space phonyTargets = maximum (20 : map ((+ 5) . length . fst) phonyTargets)
+
+-- | Show a target.
+-- Concatenates the target with its help message and inserts whitespace between them.
+showTarget :: Int -> TargetDescription -> String
+showTarget spaces (target, msg) =
+  target ++ replicate (spaces - length target) ' ' ++ msg

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -1,0 +1,98 @@
+module Stack where
+
+import           Development.Shake
+import           Development.Shake.Command
+import           Development.Shake.FilePath
+import           Control.Exception
+import           Control.Monad
+import           Data.List
+import           System.Directory                         ( copyFile )
+import           System.FilePath                          ( splitSearchPath, searchPathSeparator, (</>) )
+import           System.Environment                       ( lookupEnv, setEnv, getEnvironment )
+import           System.IO.Error                          ( isDoesNotExistError )
+import           BuildSystem
+import           Version
+import           Print
+import           Env
+
+stackBuildHie :: VersionNumber -> Action ()
+stackBuildHie versionNumber = execStackWithGhc_ versionNumber ["build"]
+  `actionOnException` liftIO (putStrLn stackBuildFailMsg)
+
+-- | copy the built binaries into the localBinDir
+stackInstallHie :: VersionNumber -> Action ()
+stackInstallHie versionNumber = do
+  execStackWithGhc_ versionNumber ["install"]
+  localBinDir <- getLocalBin
+  let hie = "haskell-ide" <.> exe
+  liftIO $ do
+    copyFile (localBinDir </> hie)
+             (localBinDir </> "haskell-ide-" ++ versionNumber <.> exe)
+    copyFile (localBinDir </> hie)
+             (localBinDir </> "haskell-ide-" ++ dropExtension versionNumber <.> exe)
+
+-- | check `stack` has the required version
+checkStack :: Action ()
+checkStack = do
+  stackVersion <- trimmedStdout <$> execStackShake ["--numeric-version"]
+  unless (checkVersion requiredStackVersion stackVersion) $ do
+    printInStars $ stackExeIsOldFailMsg stackVersion
+    error $ stackExeIsOldFailMsg stackVersion
+
+-- | Get the local binary path of stack.
+-- Equal to the command `stack path --local-bin`
+getLocalBin :: Action FilePath
+getLocalBin = do
+  Stdout stackLocalDir' <- execStackShake ["path", "--local-bin"]
+  return $ trim stackLocalDir'
+
+stackBuildData :: Action ()
+stackBuildData = do
+  execStackShake_ ["build", "hoogle"]
+  execStackShake_ ["exec", "hoogle", "generate"]
+
+-- | Execute a stack command for a specified ghc, discarding the output
+execStackWithGhc_ :: VersionNumber -> [String] -> Action ()
+execStackWithGhc_ versionNumber args = do
+  let stackFile = "stack-" ++ versionNumber ++ ".yaml"
+  command_ [] "stack" (("--stack-yaml=" ++ stackFile) : args)
+
+-- | Execute a stack command for a specified ghc
+execStackWithGhc :: CmdResult r => VersionNumber -> [String] -> Action r
+execStackWithGhc versionNumber args = do
+  let stackFile = "stack-" ++ versionNumber ++ ".yaml"
+  command [] "stack" (("--stack-yaml=" ++ stackFile) : args)
+
+-- | Execute a stack command with the same resolver as the build script
+execStackShake :: CmdResult r => [String] -> Action r
+execStackShake args = command [] "stack" ("--stack-yaml=install/shake.yaml" : args)
+
+-- | Execute a stack command with the same resolver as the build script, discarding the output
+execStackShake_ :: [String] -> Action ()
+execStackShake_ args = command_ [] "stack" ("--stack-yaml=install/shake.yaml" : args)
+
+
+-- | Error message when the `stack` binary is an older version
+stackExeIsOldFailMsg :: String -> String
+stackExeIsOldFailMsg stackVersion =
+  "The `stack` executable is outdated.\n"
+    ++ "found version is `"
+    ++ stackVersion
+    ++ "`.\n"
+    ++ "required version is `"
+    ++ versionToString requiredStackVersion
+    ++ "`.\n"
+    ++ "Please run `stack upgrade` to upgrade your stack installation"
+
+requiredStackVersion :: RequiredVersion
+requiredStackVersion = [2, 1, 1]
+
+-- |Stack build fails message
+stackBuildFailMsg :: String
+stackBuildFailMsg =
+  embedInStars
+    $  "Building failed, "
+    ++ "Try running `stack clean` and restart the build\n"
+    ++ "If this does not work, open an issue at \n"
+    ++ "\thttps://github.com/haskell/haskell-ide-engine"
+

--- a/install/src/Version.hs
+++ b/install/src/Version.hs
@@ -1,0 +1,24 @@
+module Version where
+
+import           Data.Version                             ( Version
+                                                          , parseVersion
+                                                          , makeVersion
+                                                          , showVersion
+                                                          )
+import           Text.ParserCombinators.ReadP             ( readP_to_S )
+import           Control.Monad.IO.Class
+
+
+type VersionNumber = String
+type RequiredVersion = [Int]
+
+versionToString :: RequiredVersion -> String
+versionToString = showVersion . makeVersion
+
+-- | Parse a version-string into a version. Fails if the version-string is not valid
+parseVersionEx :: String -> Version
+parseVersionEx = fst . head . filter (("" ==) . snd) . readP_to_S parseVersion
+
+-- | Check that a given version-string is not smaller than the required version
+checkVersion :: RequiredVersion -> String -> Bool
+checkVersion required given = parseVersionEx given >= makeVersion required


### PR DESCRIPTION
Renamed the string stuff to be "haskell-ide-" instead of "hie-",
nothing else changed.

Initial hand tests show it working for stack installs.

Closes #14